### PR TITLE
Fixing some typos on search forms

### DIFF
--- a/Miiworse/ClientApp/components/forms/CommunitySearchForm.tsx
+++ b/Miiworse/ClientApp/components/forms/CommunitySearchForm.tsx
@@ -11,7 +11,7 @@ export class CommunitySearchForm extends React.Component<{ search: GameSearch },
 
     @observable isOpen: boolean = false;
     @observable isDirty: boolean = false;
-    @observable searchText: string = "Show Advance Search Options";
+    @observable searchText: string = "Show Advanced Search Options";
 
     updateProperty(key, value) {
         this.props.search[key] = value;

--- a/Miiworse/ClientApp/components/forms/PostSearchForm.tsx
+++ b/Miiworse/ClientApp/components/forms/PostSearchForm.tsx
@@ -13,7 +13,7 @@ export class PostSearchForm extends React.Component<{ search: PostSearch }, {}> 
     
     @observable isOpen: boolean = false;
     @observable isDirty: boolean = false;
-    @observable searchText: string = "Show Advance Search Options";
+    @observable searchText: string = "Show Advanced Search Options";
     
     refs: {
         communityPickerModal: CommunityPickerModal;

--- a/Miiworse/ClientApp/components/forms/UserSearchForm.tsx
+++ b/Miiworse/ClientApp/components/forms/UserSearchForm.tsx
@@ -12,7 +12,7 @@ export class UserSearchForm extends React.Component<{ search: UserSearch }, {}> 
 
     @observable isOpen: boolean = false;
     @observable isDirty: boolean = false;
-    @observable searchText: string = "Show Advance Search Options";
+    @observable searchText: string = "Show Advanced Search Options";
     constants: Constants = new Constants();
 
     updateProperty(key, value) {


### PR DESCRIPTION
Noticed the forms said "Advance Search" which just sounds weird. Should be "Advanced"